### PR TITLE
Some boundary checking to keep working

### DIFF
--- a/pylint_mongoengine/checkers/mongoengine.py
+++ b/pylint_mongoengine/checkers/mongoengine.py
@@ -72,13 +72,21 @@ class MongoEngineChecker(BaseChecker):
 
     @check_messages('no-member')
     def visit_call(self, node):
+        children = node.get_children()
+        if children is None:
+        	return False
 
-        attr = next(node.get_children())
+        attr = next(children)
         meth = safe_infer(attr)
         if meth:
             return False
 
-        attr_self = safe_infer(attr.last_child())
+        last_child = attr.last_child()
+
+        if last_child is None:
+            return False
+
+        attr_self = safe_infer(last_child)
         cls = getattr(attr_self, '_proxied', None)
 
         if node_is_subclass(cls, *DOCUMENT_BASES) and not name_is_from_model(

--- a/pylint_mongoengine/suppression.py
+++ b/pylint_mongoengine/suppression.py
@@ -40,8 +40,15 @@ def _is_custom_qs_manager(funcdef):
 
 def _is_call2custom_manager(node):
     """Checks if the call is being done to a custom queryset manager."""
+    if node.func is None:
+        return False
+
     called = safe_infer(node.func)
     funcdef = getattr(called, '_proxied', None)
+
+    if funcdef is None:
+        return False
+
     return _is_custom_qs_manager(funcdef)
 
 


### PR DESCRIPTION
I was getting tons of `'NoneType' object has no attribute 'infer'` errors when using pylint-mongoengine.

By doing some boundary checks I managed to get it working fine.

Hope it helps.