### PR TITLE
Fix handling of function passed as parameter

### DIFF
--- a/pylint_mongoengine/checkers/mongoengine.py
+++ b/pylint_mongoengine/checkers/mongoengine.py
@@ -72,13 +72,19 @@ class MongoEngineChecker(BaseChecker):
 
     @check_messages('no-member')
     def visit_call(self, node):
+        children = node.get_children()
 
-        attr = next(node.get_children())
+        attr = next(children)
         meth = safe_infer(attr)
         if meth:
             return False
 
-        attr_self = safe_infer(attr.last_child())
+        last_child = attr.last_child()
+
+        if last_child is None:
+            return False
+
+        attr_self = safe_infer(last_child)
         cls = getattr(attr_self, '_proxied', None)
 
         if node_is_subclass(cls, *DOCUMENT_BASES) and not name_is_from_model(

--- a/tests/functional/input/func_noerror_func_param.py
+++ b/tests/functional/input/func_noerror_func_param.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Juca Crispim <juca@poraodojuca.net>
+
+# This file is part of pylint-mongoengine.
+
+# pylint-mongoengine is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pylint-mongoengine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with pylint-mongoengine. If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=missing-docstring
+
+
+def something(some_fn):
+    return some_fn('bla')

--- a/tests/functional/input/func_unknown_fn.py
+++ b/tests/functional/input/func_unknown_fn.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Juca Crispim <juca@poraodojuca.net>
+
+# This file is part of pylint-mongoengine.
+
+# pylint-mongoengine is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pylint-mongoengine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with pylint-mongoengine. If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=missing-docstring,undefined-variable
+
+
+# So, the thing here is that the mongoengine checker was breaking with
+# unkonw names, so we check that is not breaking and warning about
+# undefined-variable
+
+def something():
+    return some_fn('bla')

--- a/toxicbuild.yml
+++ b/toxicbuild.yml
@@ -40,8 +40,6 @@ builders:
       - <<: *TESTS_CMD
 
   - name: python3.7
-    branches:
-      - master
 
     plugins:
       - name: python-venv


### PR DESCRIPTION
Investigating the reports of pr #3  I discovered that pylint-mongoengine was breaking with functions passed as parameters.

```python
def a_func(some_fn):
    return some_fn('bla')  # here was breaking stuff
```

And also was breaking stuff with undefined function names.

```python
def a_func():
    some_undefined_fn('bla')  # here should warning about undefined not break everything.
```

This pr fix these cases using the changes from pr #3 and add some tests for them.