### PR TITLE
Add compatibility with pylint >= 3.0.0

### DIFF
--- a/pylint_mongoengine/checkers/mongoengine.py
+++ b/pylint_mongoengine/checkers/mongoengine.py
@@ -22,6 +22,11 @@ try:
 except ImportError:
     # Pylint versions <3.0.0 can use the `check_messages` fn instead
     from pylint.checkers.utils import check_messages as only_required_for_messages
+try:
+    from pylint.interfaces import IAstroidChecker
+# pylint versions >=3.0.0 don't use IAstroidChecker
+except ImportError:
+    pass
 
 from pylint_mongoengine.utils import (
     name_is_from_qs,
@@ -30,6 +35,12 @@ from pylint_mongoengine.utils import (
 
 
 class MongoEngineChecker(BaseChecker):
+
+    try:
+        __implements__ = IAstroidChecker
+    # pylint versions >=3.0.0 don't use IAstroidChecker
+    except NameError:
+        pass
 
     name = 'mongoengine-checker'
 

--- a/pylint_mongoengine/checkers/mongoengine.py
+++ b/pylint_mongoengine/checkers/mongoengine.py
@@ -17,7 +17,11 @@
 # along with pylint-mongoengine. If not, see <http://www.gnu.org/licenses/>.
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
+try:
+    from pylint.checkers.utils import only_required_for_messages
+except ImportError:
+    # Pylint versions <3.0.0 can use the `check_messages` fn instead
+    from pylint.checkers.utils import check_messages as only_required_for_messages
 from pylint.interfaces import IAstroidChecker
 
 from pylint_mongoengine.utils import (
@@ -53,6 +57,6 @@ class MongoEngineChecker(BaseChecker):
             self.add_message('no-member', node=node, args=(
                 'QuerySet instance', 'objects', node.attrname, ''))
 
-    @check_messages('no-member')
+    @only_required_for_messages('no-member')
     def visit_attribute(self, node):
         self.check_qs_name(node)

--- a/pylint_mongoengine/checkers/mongoengine.py
+++ b/pylint_mongoengine/checkers/mongoengine.py
@@ -22,7 +22,6 @@ try:
 except ImportError:
     # Pylint versions <3.0.0 can use the `check_messages` fn instead
     from pylint.checkers.utils import check_messages as only_required_for_messages
-from pylint.interfaces import IAstroidChecker
 
 from pylint_mongoengine.utils import (
     name_is_from_qs,
@@ -31,8 +30,6 @@ from pylint_mongoengine.utils import (
 
 
 class MongoEngineChecker(BaseChecker):
-
-    __implements__ = IAstroidChecker
 
     name = 'mongoengine-checker'
 


### PR DESCRIPTION
This MR adds compatibility with pylint versions >= 3.0.0. Since this MR introduces several breaking changes, we may need more changes than these. But at least, it works on my machine … in my project.

This should not introduce any breaking changes.

Closes #17 